### PR TITLE
Add sanity check for 'Duration 0' in BlueConfig

### DIFF
--- a/src/data/sonata_data.cpp
+++ b/src/data/sonata_data.cpp
@@ -98,13 +98,16 @@ void SonataData::prepare_buffer(size_t max_buffer_size) {
 }
 
 bool SonataData::is_due_to_report(double step) const noexcept {
-    // Dont record data if current step < tstart
-    if (step < last_step_recorded_) {
+    // Don't record data if there are no steps (i.e., 'Duration 0')
+    if (last_step_ == 0) {
         return false;
-        // Dont record data if current step > tend
+        // Don't record data if current step < tstart
+    } else if (step < last_step_recorded_) {
+        return false;
+        // Don't record data if current step > tend
     } else if (step > last_step_) {
         return false;
-        // Dont record data if is not a reporting step (step%period)
+        // Don't record data if is not a reporting step (step%period)
     } else if (static_cast<int>(step - last_step_recorded_) % reporting_period_ != 0) {
         return false;
     }


### PR DESCRIPTION
Setting `Duration 0` inside a BlueConfig file causes `libsonata-report` to produce a `SIGSEGV`:

```Bash
...
>>>> MPT: #6  0x00002aaaabf8afdb in transform (__first=..., __last=..., __result=..., 
MPT:     __unary_op=...)
MPT:     at /gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/compilers/2021-01-06/linux-rhel7-x86_64/gcc-4.8.5/gcc-9.3.0-45gzrp/include/c++/9.3.0/bits/stl_algo.h:4337
>>>> MPT: #7  bbp::sonata::Node::fill_data (this=0x0, it=...)
MPT:     at /gpfs/bbp.cscs.ch/ssd/slurmTmpFS/bbprelman/2225491/spack-stage-libsonata-report-1.0.0.20210610-x5el37sujjlpvjaa2dzsgu54kp7tcy6x/spack-src/src/data/node.cpp:17
>>>> MPT: #8  0x00002aaaabf926e4 in bbp::sonata::SonataData::record_data (this=0x0, 
MPT:     step=0)
MPT:     at /gpfs/bbp.cscs.ch/ssd/slurmTmpFS/bbprelman/2225491/spack-stage-libsonata-report-1.0.0.20210610-x5el37sujjlpvjaa2dzsgu54kp7tcy6x/spack-src/src/data/sonata_data.cpp:162
>>>> MPT: #9  0x00002aaaabf7fba8 in bbp::sonata::Report::record_data (this=0x0, step=0)
MPT:     at /gpfs/bbp.cscs.ch/ssd/slurmTmpFS/bbprelman/2225491/spack-stage-libsonata-report-1.0.0.20210610-x5el37sujjlpvjaa2dzsgu54kp7tcy6x/spack-src/src/library/report.cpp:92
...
```

This small change prevents the issue by ensuring that the `last_step_` of the simulation is greater than `0`. Below is the simulation output with the fix:

```Bash
...
[STEP] Enabling modifications...
[STEP] Reports Enabling
[INFO]  * soma_SONATA (Type: compartment, Target: Mosaic)
[REPORTS] [info] :: Initializing PARALLEL implementation...
[REPORTS] [info] :: Initializing communicators and preparing SONATA datasets
[INFO] Preparing to run simulation...
[INFO] Executing actions after stdinit...
[STEP] ======================= SIMULATION =======================
[INFO] Running simulation until t=0 ms
[INFO] Simulation finished.
[INFO] Writing spikes to out.dat
[DEBUG] Memusage [MB]: Max=150.21, Min=150.21, Mean(Stdev)=150.21(0.00)
[INFO] Clearing model
[INFO] Finished
...
```