### PR TITLE
Save reports in a map to keep the order

### DIFF
--- a/src/library/sonatareport.h
+++ b/src/library/sonatareport.h
@@ -18,7 +18,7 @@ namespace sonata {
  */
 class SonataReport
 {
-    using reports_t = std::unordered_map<std::string, std::shared_ptr<Report>>;
+    using reports_t = std::map<std::string, std::shared_ptr<Report>>;
 #ifdef SONATA_REPORT_HAVE_MPI
     using communicators_t = std::unordered_map<std::string, MPI_Comm>;
 #endif


### PR DESCRIPTION
 - Fix deadlock that could happen when looping through the reports
   and 2 different ranks start preparing datasets for different reports
   and wait for eachother