### PR TITLE
Fix REP-79: Avoid buffer overflow during recording of data

### DIFF
--- a/src/data/sonata_data.cpp
+++ b/src/data/sonata_data.cpp
@@ -114,6 +114,16 @@ void SonataData::record_data(double step, const std::vector<uint64_t>& node_ids)
     // Calculate the offset to write into the buffer
     uint32_t offset = static_cast<uint32_t>((step - last_step_recorded_) / reporting_period_);
     uint32_t local_position = last_position_ + total_elements_ * offset;
+
+    if (steps_recorded_ >= num_steps_) {
+        if (SonataReport::rank_ == 0) {
+            logger->trace("Already recorded {} steps, skipping report recording for {} population",
+                          steps_recorded_,
+                          population_name_);
+        }
+        return;
+    }
+
     if (SonataReport::rank_ == 0) {
         logger->trace(
             "Recording data for population {}, step={} last_step_recorded={} steps recorded {} "
@@ -146,6 +156,16 @@ void SonataData::record_data(double step, const std::vector<uint64_t>& node_ids)
 
 void SonataData::record_data(double step) {
     uint32_t local_position = last_position_;
+
+    if (steps_recorded_ >= num_steps_) {
+        if (SonataReport::rank_ == 0) {
+            logger->trace("Already recorded {} steps, skipping report recording for {} population",
+                          steps_recorded_,
+                          population_name_);
+        }
+        return;
+    }
+
     if (SonataReport::rank_ == 0) {
         logger->trace(
             "Recording data for step={} last_step_recorded={} buffer_size={} and offset={}",

--- a/src/data/sonata_data.cpp
+++ b/src/data/sonata_data.cpp
@@ -115,7 +115,7 @@ void SonataData::record_data(double step, const std::vector<uint64_t>& node_ids)
     uint32_t offset = static_cast<uint32_t>((step - last_step_recorded_) / reporting_period_);
     uint32_t local_position = last_position_ + total_elements_ * offset;
 
-    if (steps_recorded_ >= num_steps_) {
+    if (steps_recorded_ >= steps_to_write_) {
         if (SonataReport::rank_ == 0) {
             logger->trace("Already recorded {} steps, skipping report recording for {} population",
                           steps_recorded_,
@@ -157,7 +157,7 @@ void SonataData::record_data(double step, const std::vector<uint64_t>& node_ids)
 void SonataData::record_data(double step) {
     uint32_t local_position = last_position_;
 
-    if (steps_recorded_ >= num_steps_) {
+    if (steps_recorded_ >= steps_to_write_) {
         if (SonataReport::rank_ == 0) {
             logger->trace("Already recorded {} steps, skipping report recording for {} population",
                           steps_recorded_,


### PR DESCRIPTION
- As explained in [REP-79](https://bbpteam.epfl.ch/project/issues/browse/REP-79), when report dt is equal to sim dt and duration then we see segfault.
- This is because the simulator stops a bit after the duration and we end up recording 2 timesteps than one.
- Now make sure we skip additional timesteps if we try to record
  them somehow from the simulator side.


I hope the CI will be green here: https://bbpgitlab.epfl.ch/hpc/sim/blueconfigs/-/pipelines/69279