### PR TITLE
[REP-86] Fix bugs in spikes_converter

### DIFF
--- a/src/library/implementation_interface.hpp
+++ b/src/library/implementation_interface.hpp
@@ -315,6 +315,9 @@ struct ParallelImplementation {
         // first find number of spikes in each time window
         for (const auto& st : spikevec_time) {
             int idx = (int) (st - min_time) / bin_t;
+            if (idx >= numprocs) {
+                idx = numprocs - 1;
+            }
             snd_cnts[idx]++;
         }
 

--- a/tools/converter/spikes_converter.cpp
+++ b/tools/converter/spikes_converter.cpp
@@ -51,21 +51,21 @@ int main(int argc, char* argv[]) {
         return -2;
     }
 
-    // remove /scatter
+    // remove /scatter and # commented lines
     std::string scatter;
     getline(infile, scatter);
-    if (scatter != "/scatter") {
+    if (scatter != "/scatter" && scatter[0] != '#') {
         infile.seekg(0, std::ios::beg);
     }
 
     std::vector<double> spike_timestamps;
     std::vector<int> spike_node_ids;
     double timestamp;
-    int node_id;
-
+    // Some files could have node_ids as double
+    double node_id;
     while (infile >> timestamp >> node_id) {
         spike_timestamps.push_back(timestamp);
-        spike_node_ids.push_back(node_id);
+        spike_node_ids.push_back(static_cast<int>(node_id));
     }
 
     // Create a spike file


### PR DESCRIPTION
 - Skip the first line if its '/scatter' or starts by a comment '#'
 - Allow the node_ids to be represented by doubles
 - Fixed out-of-bounds error in spike sorting by ensuring index is within range of counts vector