### PR TITLE
[REP-87] Add unit details to converted reports and converter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,49 @@ cmake  -DCMAKE_BUILD_TYPE=Release  -DSONATA_REPORT_ENABLE_SUBMODULES=ON ..
 make -j
 ```
 
+# Usage
+
+This section provides guidance on how to use the tools provided by libsonatareport for converting report and spike files into the SONATA format.
+
+## Prerequisites
+
+Before using the conversion tools, ensure the library is compiled with the converter enabled by including the cmake flag `-DSONATA_REPORT_ENABLE_CONVERTER=ON` during the installation process described in the "Installation" section.
+
+## Tools
+
+### Report Converter
+
+Converts `.bbp` format files, typically containing voltage or current reports from simulations, into the SONATA format.
+
+```shell
+reports_converter <report_filename> <report_type> [population_name]
+
+Example:
+    reports_converter soma.bbp --soma PopulationA
+```
+This command will convert the soma report `soma.bbp` for population 'PopulationA' into the SONATA format as `soma.bbp.h5`
+
+### Spikes Converter
+
+The spikes converter tool is designed to convert old `.dat` spike files into the SONATA format.
+
+```shell
+spikes_converter <spike_filename> [population_name]
+
+Example:
+    spikes_converter out.dat PopulationB
+```
+
+This command will convert the spike file `out.dat` for population 'PopulationB' into the SONATA format as `out.dat.h5`
+
+## Additional Information
+
+For more detailed information on the usage of these converters, including additional options and examples, you can run them with the `--help` flag to display the usage:
+
+```shell
+reports_converter --help
+spikes_converter --help
+```
 
 # Funding & Acknowledgment
  

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ https://github.com/AllenInstitute/sonata/blob/master/docs/SONATA_DEVELOPER_GUIDE
 ```shell
 git clone git@github.com:BlueBrain/libsonatareport.git --recursive
 cd libsonatareport
-mkdir build && cd build
-cmake  -DCMAKE_BUILD_TYPE=Release  -DSONATA_REPORT_ENABLE_SUBMODULES=ON ..
-make -j
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -GNinja
+cmake --build build
 ```
 
 # Usage

--- a/tools/converter/reports_converter.cpp
+++ b/tools/converter/reports_converter.cpp
@@ -70,8 +70,9 @@ int main(int argc, char* argv[]) {
     double tstart = header.get_start_time();
     double tstop = header.get_end_time();
     double dt = header.get_time_step_size();
+    std::string data_unit = header.get_data_unit();
     logger->info("Report info: tstart = '{}', tstop = '{}', dt = '{}'", tstart, tstop, dt);
-    sonata_create_report(report_name.data(), tstart, tstop, dt, "mV", "compartment");
+    sonata_create_report(report_name.data(), tstart, tstop, dt, data_unit.data(), "compartment");
 
     // Get Cell information to create node/element structure
     // TODO: check if it could be done without getting the FrameParser per gid


### PR DESCRIPTION
Addresses REP-87.
The report converter was hardcoding "mV" for all kind of reports. Now it takes into account the units.
Added documentation for the spikes and report converters.