### PR TITLE
[REP-88] Add function to update compartment pointers

### DIFF
--- a/include/bbp/sonata/reports.h
+++ b/include/bbp/sonata/reports.h
@@ -52,6 +52,23 @@ int sonata_add_element(const char* report_name,
                        uint64_t node_id,
                        uint32_t element_id,
                        double* element_value);
+
+/*!
+ * \brief Update multiple elements to an existing node on a report
+ * \param report_name name of the report
+ * \param population_name name of the population
+ * \param node_id node identifier
+ * \param element_ids array of element identifiers
+ * \param element_values array of pointers to element values
+ * \return 0 if operator succeeded, -2 if the report doesn't exist, -3 if the specified node
+ * doesn't exist, -1 for other errors.
+ */
+int sonata_update_elements(const char* report_name,
+                           const char* population_name,
+                           uint64_t node_id,
+                           const uint32_t* element_ids,
+                           double** element_values);
+
 /**
  * \brief Setup buffers and create datasets
  * \return 0

--- a/include/bbp/sonata/reports.h
+++ b/include/bbp/sonata/reports.h
@@ -71,14 +71,18 @@ int sonata_update_elements(const char* report_name,
 
 /**
  * \brief Setup buffers and create datasets
- * \return 0
  */
-int sonata_prepare_datasets();
+void sonata_prepare_datasets();
 
 /**
  * \brief Initialize communicators
  */
 void sonata_setup_communicators();
+
+/**
+ * \brief Initialize reports
+ */
+void sonata_setup_reports();
 
 /**
  * \brief Minimum number steps needed to allocate in a single buffer

--- a/src/data/node.cpp
+++ b/src/data/node.cpp
@@ -30,6 +30,29 @@ void Node::add_element(std::function<double()> element_value, uint32_t element_i
     element_ids_.push_back(element_id);
 }
 
+void Node::update_elements(std::vector<uint32_t> element_ids, std::vector<double*> element_values) {
+    if (element_ids.size() != element_values.size()) {
+        throw std::runtime_error(
+            "bbp::sonata::Node::update_elements: element_ids and element_values must have the same "
+            "size");
+    } else if (!elements_.empty()) {
+        if (element_ids.size() != element_ids_.size()) {
+            throw std::runtime_error(
+                "bbp::sonata::Node::update_elements: element_ids and internal element_ids_ must "
+                "have the same size");
+        }
+        for (size_t i = 0; i < element_ids.size(); ++i) {
+            if (element_ids[i] != element_ids_[i]) {
+                throw std::runtime_error(
+                    "bbp::sonata::Node::update_elements: element_ids must be in the same order as "
+                    "internal element_ids_");
+            }
+            elements_[i] = element_values[i];
+        }
+    }
+}
+
+
 void Node::fill_data(std::vector<float>::iterator it) {
     assert(elements_.empty() || element_handles_.empty());
     if (!elements_.empty()) {

--- a/src/data/node.h
+++ b/src/data/node.h
@@ -17,6 +17,8 @@ class Node
     void refresh_pointers(std::function<double*(double*)> refresh_function);
     virtual void add_element(double* element_value, uint32_t element_id);
     virtual void add_element(std::function<double()> element_value, uint32_t element_id);
+    virtual void update_elements(std::vector<uint32_t> element_ids,
+                                 std::vector<double*> element_values);
 
     uint64_t get_node_id() const noexcept {
         return node_id_;

--- a/src/data/soma_node.cpp
+++ b/src/data/soma_node.cpp
@@ -24,5 +24,14 @@ void SomaNode::add_element(std::function<double()> element_value, uint32_t eleme
     element_ids_.push_back(element_id);
 }
 
+void SomaNode::update_elements(std::vector<uint32_t> element_ids,
+                               std::vector<double*> element_values) {
+    if (element_ids.size() != 1 || element_ids_[0] != element_ids[0]) {
+        throw std::runtime_error(
+            "ERROR: Soma report nodes can only have 1 element and IDs must match");
+    }
+    elements_ = std::move(element_values);
+    element_ids_ = std::move(element_ids);
+}
 }  // namespace sonata
 }  // namespace bbp

--- a/src/data/soma_node.h
+++ b/src/data/soma_node.h
@@ -11,6 +11,8 @@ class SomaNode: public Node
 
     void add_element(double* element_value, uint32_t element_id) override;
     void add_element(std::function<double()> element_value, uint32_t element_id) override;
+    void update_elements(std::vector<uint32_t> element_ids,
+                         std::vector<double*> element_values) override;
     size_t get_num_elements() const noexcept override {
         return elements_.empty() ? 0 : 1;
     };

--- a/src/library/reports.cpp
+++ b/src/library/reports.cpp
@@ -86,6 +86,31 @@ int sonata_add_element_handle(const char* report_name,
         report_name, population_name, node_id, element_id, std::move(element_value));
 }
 
+int sonata_update_elements(const char* report_name,
+                           const char* population_name,
+                           uint64_t node_id,
+                           const uint32_t* element_ids,
+                           double** element_values) {
+    if (!sonata_report.report_exists(report_name)) {
+        return -2;
+    }
+    try {
+        auto report = sonata_report.get_report(report_name);
+        auto node = report->get_node(population_name, node_id);
+        std::vector<uint32_t> element_ids_vec(element_ids, element_ids + node->get_num_elements());
+        std::vector<double*> element_values_vec(element_values,
+                                                element_values + node->get_num_elements());
+        node->update_elements(element_ids_vec, element_values_vec);
+    } catch (const std::out_of_range& err) {
+        logger->error(err.what());
+        return -3;
+    } catch (const std::exception& err) {
+        logger->error(err.what());
+        return -1;
+    }
+    return 0;
+}
+
 void sonata_setup_communicators() {
     sonata_report.create_communicators();
 }

--- a/src/library/reports.cpp
+++ b/src/library/reports.cpp
@@ -118,9 +118,12 @@ void sonata_setup_communicators() {
     sonata_report.create_communicators();
 }
 
-int sonata_prepare_datasets() {
+void sonata_prepare_datasets() {
     sonata_report.prepare_datasets();
-    return 0;
+}
+
+void sonata_setup_reports() {
+    sonata_report.setup_reports();
 }
 
 void sonata_set_min_steps_to_record(int steps) {

--- a/src/library/reports.cpp
+++ b/src/library/reports.cpp
@@ -19,6 +19,9 @@ int sonata_create_report(const char* report_name,
     try {
         if (!sonata_report.report_exists(report_name)) {
             sonata_report.create_report(report_name, kind, tstart, tend, dt, units);
+        } else {
+            logger->warn("Report '{}' already exists.", report_name);
+            return -2;
         }
     } catch (const std::exception& err) {
         logger->error(err.what());

--- a/src/library/sonatareport.cpp
+++ b/src/library/sonatareport.cpp
@@ -63,6 +63,14 @@ bool SonataReport::report_exists(const std::string& name) const {
     return reports_.find(name) != reports_.end();
 }
 
+void SonataReport::setup_reports() {
+    if (!reports_initialized_) {
+        create_communicators();
+        prepare_datasets();
+        reports_initialized_ = true;
+    }
+}
+
 void SonataReport::create_communicators() {
     std::vector<std::string> report_names;
     report_names.reserve(reports_.size());

--- a/src/library/sonatareport.h
+++ b/src/library/sonatareport.h
@@ -57,6 +57,7 @@ class SonataReport
 
     void create_communicators();
     void prepare_datasets();
+    void setup_reports();
 
     void create_spikefile(const std::string& output_dir, const std::string& filename = "out");
     void add_spikes_population(const std::string& population_name,
@@ -77,6 +78,7 @@ class SonataReport
   private:
     reports_t reports_;
     std::unique_ptr<SonataData> spike_data_;
+    bool reports_initialized_ = false;
 };
 
 }  // namespace sonata

--- a/tests/integration/integration_test.cpp
+++ b/tests/integration/integration_test.cpp
@@ -189,8 +189,7 @@ int main() {
     sonata_set_max_buffer_size_hint(20);
     sonata_set_atomic_step(dt);
 
-    sonata_setup_communicators();
-    sonata_prepare_datasets();
+    sonata_setup_reports();
     sonata_time_data();
 
     if (global_rank == 0) {
@@ -236,8 +235,7 @@ int main() {
          "soma",
          units);
 
-    sonata_setup_communicators();
-    sonata_prepare_datasets();
+    sonata_setup_reports();
     sonata_write_buffered_data(buffered_soma_report, soma_buffered_data.data(), soma_buffered_data.size(), num_steps);
     sonata_clear();
 

--- a/tests/unit/test_node.cpp
+++ b/tests/unit/test_node.cpp
@@ -52,6 +52,48 @@ SCENARIO("Test Node class", "[Node]") {
                 node.fill_data(result.begin());
                 REQUIRE(result == compare);
             }
+            THEN("update_elements with different sizes in elements should fail") {
+                // Sizes of element_ids and element_values differ
+                std::vector<uint32_t> element_ids = {0, 1, 2, 3, 4};
+                std::vector<double> new_elements = {100, 111, 122};
+                std::vector<double*> element_values;
+                for (auto& element : new_elements) {
+                    element_values.push_back(&element);
+                }
+                REQUIRE_THROWS(node.update_elements(element_ids, element_values));
+            }
+            THEN("update_elements with wrong size should fail") {
+                // Initial node has 5 elements
+                std::vector<uint32_t> element_ids = {0, 1, 2};
+                std::vector<double> new_elements = {100, 111, 122};
+                std::vector<double*> element_values;
+                for (auto& element : new_elements) {
+                    element_values.push_back(&element);
+                }
+                REQUIRE_THROWS(node.update_elements(element_ids, element_values));
+            }
+            THEN("update_elements with different element_ids should fail") {
+                // Initial node has {0,1,2,3,4} element_ids
+                std::vector<uint32_t> element_ids = {0, 1, 2, 3, 5};
+                std::vector<double> new_elements = {100, 111, 122, 133, 144};
+                std::vector<double*> element_values;
+                for (auto& element : new_elements) {
+                    element_values.push_back(&element);
+                }
+                REQUIRE_THROWS(node.update_elements(element_ids, element_values));
+            }
+            THEN("update_elements should update the pointers") {
+                std::vector<uint32_t> element_ids = {0, 1, 2, 3, 4};
+                std::vector<double> new_elements = {100, 111, 122, 133, 144};
+                std::vector<double*> element_values;
+                for (auto& element : new_elements) {
+                    element_values.push_back(&element);
+                }
+                node.update_elements(element_ids, element_values);
+                std::vector<float> result(5, -1.);
+                node.fill_data(result.begin());
+                REQUIRE(result == std::vector<float>(new_elements.begin(), new_elements.end()));
+            }
         }
 
         WHEN("We add a std::function<double()> element") {

--- a/tests/unit/test_sonatareport.cpp
+++ b/tests/unit/test_sonatareport.cpp
@@ -118,8 +118,7 @@ SCENARIO("Test SonataReport API", "[sonatareport]") {
                 auto num_steps = static_cast<int>(std::ceil(sim_steps));
 
                 sonata_set_atomic_step(dt);
-                sonata_setup_communicators();
-                sonata_prepare_datasets();
+                sonata_setup_reports();
 
                 sonata_set_min_steps_to_record(10);
 

--- a/tests/unit/test_sonatareport.cpp
+++ b/tests/unit/test_sonatareport.cpp
@@ -17,139 +17,147 @@ SCENARIO("Test SonataReport API", "[sonatareport]") {
     const double tstart = 0;
     const double tend = 0.3;
     const double dt = 0.1;
-
     uint32_t element_id = 142;
 
-    WHEN("We add a new report (element) and node") {
-        sonata_create_report(element_report_name, tstart, tend, dt, report_units, "compartment");
-        sonata_add_node(element_report_name, population_name, population_offset, 1);
-        THEN("Number of reports is 1") {
-            REQUIRE(sonata_get_num_reports() == 1);
-        }
-        THEN("We refresh the pointers") {
-            REQUIRE_NOTHROW(sonata_refresh_pointers(&square_value));
-        }
-    }
+    GIVEN("A new compartment report") {
+        sonata_clear();
+        int ret_report = sonata_create_report(
+            element_report_name, tstart, tend, dt, report_units, "compartment");
+        REQUIRE(ret_report == 0);
 
-    WHEN("We add a node to an existing element report") {
-        sonata_create_report(element_report_name, tstart, tend, dt, report_units, "compartment");
-        sonata_add_node(element_report_name, population_name, population_offset, 2);
-        THEN("Number of reports is still 1") {
-            REQUIRE(sonata_get_num_reports() == 1);
-        }
-    }
-
-    WHEN("We add an existing node to an existing element report") {
-        sonata_create_report(element_report_name, tstart, tend, dt, report_units, "compartment");
-        sonata_add_node(element_report_name, population_name, population_offset, 2);
-        THEN("Number of reports is still 1") {
-            REQUIRE(sonata_get_num_reports() == 1);
-        }
-    }
-
-    WHEN("We add a second report (soma), a node and a variable") {
-        sonata_create_report(soma_report_name, tstart, tend, dt, report_units, "soma");
-        sonata_add_node(soma_report_name, population_name, population_offset, 1);
-        double soma_value = 42;
-        sonata_add_element(soma_report_name, population_name, 1, element_id, &soma_value);
-        THEN("Number of reports is 2") {
-            REQUIRE(sonata_get_num_reports() == 2);
-        }
-    }
-
-    WHEN("We add a second variable to an existing node in a soma report") {
-        double soma_value = 24;
-        sonata_add_element(soma_report_name, population_name, 1, element_id, &soma_value);
-        THEN("Number of reports is 2") {
-            REQUIRE(sonata_get_num_reports() == 2);
-        }
-    }
-
-    WHEN("We add a report of a non existing type") {
-        const char* weird_report_name = "myWeirdReport";
-        sonata_create_report(weird_report_name, tstart, tend, dt, report_units, "weird");
-        THEN("Number of reports is still 2") {
-            REQUIRE(sonata_get_num_reports() == 2);
-        }
-    }
-
-    WHEN("We add a node or an element to a non existing report") {
-        const char* weird_report_name = "myWeirdReport";
-        double soma_value = 33;
-        int nodeids[2] = {1, 2};
-        THEN("Number of reports is still 2 and returns error") {
-            REQUIRE(sonata_get_num_reports() == 2);
-            REQUIRE(sonata_add_node(weird_report_name, population_name, population_offset, 1) ==
-                    -2);
-            REQUIRE(sonata_add_element(
-                        weird_report_name, population_name, 1, element_id, &soma_value) == -2);
-            REQUIRE(sonata_set_report_max_buffer_size_hint(weird_report_name, 1) == -1);
-            REQUIRE(sonata_record_node_data(1.0, 1, nodeids, weird_report_name) == -1);
-        }
-    }
-    WHEN("10 nodes with 5 elements each") {
-        // 10 nodes
-        const std::array<uint64_t, 10> node_ids{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-        std::array<double, 5> elements{3.45, 563.12, 23.4, 779.2, 42.1};
-        const char* report_name = "elementReport";
-
-        sonata_create_report(report_name, tstart, tend, dt, report_units, "compartment");
-        for (int node_id : node_ids) {
-            sonata_add_node(report_name, population_name, population_offset, node_id);
-            for (auto element_value : elements) {
-                sonata_add_element(
-                    report_name, population_name, node_id, element_id, &element_value);
+        WHEN("We create an existing report name") {
+            int ret_report = sonata_create_report(
+                element_report_name, tstart, tend, dt, report_units, "compartment");
+            THEN("Number of reports is still 1 and return value negative") {
+                REQUIRE(sonata_get_num_reports() == 1);
+                REQUIRE(ret_report < 0);
             }
         }
-        sonata_set_report_max_buffer_size_hint(report_name, 1);
-        THEN("Number of reports is 3") {
-            REQUIRE(sonata_get_num_reports() == 3);
+
+        WHEN("We add a node to an existing element report") {
+            int ret_node =
+                sonata_add_node(element_report_name, population_name, population_offset, 1);
+            REQUIRE(ret_node == 0);
+            THEN("Number of reports is 1") {
+                REQUIRE(sonata_get_num_reports() == 1);
+            }
+            THEN("We refresh the pointers") {
+                REQUIRE_NOTHROW(sonata_refresh_pointers(&square_value));
+            }
         }
-    }
 
-    WHEN("We record data") {
-        double sim_steps = (tend - tstart) / dt;
-        auto num_steps = static_cast<int>(std::ceil(sim_steps));
-
-        sonata_set_atomic_step(dt);
-        sonata_setup_communicators();
-        sonata_prepare_datasets();
-
-        sonata_set_min_steps_to_record(10);
-
-        double t = 0.0;
-        for (int i = 0; i < num_steps; i++) {
-            // Could be used like this also
-            // sonata_record_node_data(i, 10, nodeids, report_name);
-            sonata_record_data(i);
-            sonata_check_and_flush(t);
-            t += dt;
+        WHEN("We add a new node to an existing element report") {
+            int ret_node =
+                sonata_add_node(element_report_name, population_name, population_offset, 2);
+            REQUIRE(ret_node == 0);
+            THEN("Number of reports is still 1") {
+                REQUIRE(sonata_get_num_reports() == 1);
+            }
         }
-        sonata_flush(t);
-        THEN("Number of reports is still 3") {
-            REQUIRE(sonata_get_num_reports() == 3);
-        }
-    }
 
-    WHEN("We clean all reports") {
-        sonata_clear();
-        THEN("Number of reports is 0") {
-            REQUIRE(sonata_get_num_reports() == 0);
+        WHEN("We add an existing node to an existing element report") {
+            sonata_add_node(element_report_name, population_name, population_offset, 2);
+            int ret_node =
+                sonata_add_node(element_report_name, population_name, population_offset, 2);
+            THEN("Number of reports is still 1 and return value negative") {
+                REQUIRE(ret_node < 0);
+                REQUIRE(sonata_get_num_reports() == 1);
+            }
         }
-    }
 
-    WHEN("We call not implemented functions") {
-        const int values[2] = {0, 1};
-        std::string name = "report";
-        REQUIRE(sonata_extra_mapping(name.data(), 1, 2, values) == 0);
-        sonata_set_steps_to_buffer(10);
-        sonata_set_auto_flush(0);
-        REQUIRE(sonata_time_data() == 0);
-        REQUIRE(sonata_saveinit(name.data(), 1, values, values, 1) == nullptr);
-        REQUIRE(sonata_savebuffer(0) == nullptr);
-        sonata_saveglobal();
-        sonata_savestate();
-        REQUIRE(sonata_restoreinit(name.data(), values) == nullptr);
-        REQUIRE(sonata_restore(1, values, values) == nullptr);
+        WHEN("We add a second report (soma), a node and a variable") {
+            sonata_create_report(soma_report_name, tstart, tend, dt, report_units, "soma");
+            sonata_add_node(soma_report_name, population_name, population_offset, 1);
+            double soma_value = 42;
+            sonata_add_element(soma_report_name, population_name, 1, element_id, &soma_value);
+            THEN("Number of reports is 2") {
+                REQUIRE(sonata_get_num_reports() == 2);
+            }
+        }
+
+        WHEN("We add a report of a non existing type") {
+            const char* weird_report_name = "myWeirdReport";
+            sonata_create_report(weird_report_name, tstart, tend, dt, report_units, "weird");
+            THEN("Number of reports is still 1") {
+                REQUIRE(sonata_get_num_reports() == 1);
+            }
+        }
+
+        WHEN("We add a node or an element to a non existing report") {
+            const char* weird_report_name = "myWeirdReport";
+            double soma_value = 33;
+            int nodeids[2] = {1, 2};
+            THEN("Number of reports is still 1 and returns error") {
+                REQUIRE(sonata_get_num_reports() == 1);
+                REQUIRE(sonata_add_node(weird_report_name, population_name, population_offset, 1) ==
+                        -2);
+                REQUIRE(sonata_add_element(
+                            weird_report_name, population_name, 1, element_id, &soma_value) == -2);
+                REQUIRE(sonata_set_report_max_buffer_size_hint(weird_report_name, 1) == -1);
+                REQUIRE(sonata_record_node_data(1.0, 1, nodeids, weird_report_name) == -1);
+            }
+        }
+        WHEN("10 nodes with 5 elements each") {
+            // 10 nodes
+            const std::array<uint64_t, 10> node_ids{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            std::array<double, 5> elements{3.45, 563.12, 23.4, 779.2, 42.1};
+            const char* report_name = "elementReport";
+
+            sonata_create_report(report_name, tstart, tend, dt, report_units, "compartment");
+            for (int node_id : node_ids) {
+                sonata_add_node(report_name, population_name, population_offset, node_id);
+                for (auto element_value : elements) {
+                    sonata_add_element(
+                        report_name, population_name, node_id, element_id, &element_value);
+                }
+            }
+            sonata_set_report_max_buffer_size_hint(report_name, 1);
+
+            THEN("We record data") {
+                double sim_steps = (tend - tstart) / dt;
+                auto num_steps = static_cast<int>(std::ceil(sim_steps));
+
+                sonata_set_atomic_step(dt);
+                sonata_setup_communicators();
+                sonata_prepare_datasets();
+
+                sonata_set_min_steps_to_record(10);
+
+                double t = 0.0;
+                for (int i = 0; i < num_steps; i++) {
+                    // Could be used like this also
+                    // sonata_record_node_data(i, 10, nodeids, report_name);
+                    sonata_record_data(i);
+                    sonata_check_and_flush(t);
+                    t += dt;
+                }
+                sonata_flush(t);
+            }
+            THEN("Number of reports is 2") {
+                REQUIRE(sonata_get_num_reports() == 2);
+            }
+        }
+
+        WHEN("We clean all reports") {
+            sonata_clear();
+            THEN("Number of reports is 0") {
+                REQUIRE(sonata_get_num_reports() == 0);
+            }
+        }
+
+        WHEN("We call not implemented functions") {
+            const int values[2] = {0, 1};
+            std::string name = "report";
+            REQUIRE(sonata_extra_mapping(name.data(), 1, 2, values) == 0);
+            sonata_set_steps_to_buffer(10);
+            sonata_set_auto_flush(0);
+            REQUIRE(sonata_time_data() == 0);
+            REQUIRE(sonata_saveinit(name.data(), 1, values, values, 1) == nullptr);
+            REQUIRE(sonata_savebuffer(0) == nullptr);
+            sonata_saveglobal();
+            sonata_savestate();
+            REQUIRE(sonata_restoreinit(name.data(), values) == nullptr);
+            REQUIRE(sonata_restore(1, values, values) == nullptr);
+        }
     }
 }


### PR DESCRIPTION
For Polina's request in https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-762, simulation needs to be run more than once in order to change variables to report.
This works with NEURON since the memory doesn't change and the pointers are valid in the second run. For CoreNEURON, however, NrnThreads are created and deleted in each run, so the pointers become invalid.

The idea is to add a function to update the pointers of the compartments with the new pointers.