### PR TITLE
Add flush functionality to HDF5Writer

### DIFF
--- a/src/data/sonata_data.cpp
+++ b/src/data/sonata_data.cpp
@@ -357,6 +357,12 @@ void SonataData::write_data(const std::vector<float>& buffered_data, uint32_t st
 
 void SonataData::flush() {
     write_data(report_buffer_, current_step_);
+    if (getenv("LIBSONATAREPORT_ENABLE_FLUSH") != nullptr) {
+        if (SonataReport::rank_ == 0) {
+            logger->debug("Flushing data from report {}", report_name_);
+        }
+        hdf5_writer_->flush();
+    }
 }
 
 void SonataData::close() {

--- a/src/io/hdf5_writer.cpp
+++ b/src/io/hdf5_writer.cpp
@@ -167,6 +167,10 @@ void HDF5Writer::write_time(const std::string& dataset_name, const std::array<do
     H5Sclose(data_space);
 }
 
+void HDF5Writer::flush() {
+    H5Fflush(file_, H5F_SCOPE_GLOBAL);
+}
+
 void HDF5Writer::close() {
     // We close the dataset "/data", the spike enum type and the hdf5 file
     if (dataset_) {

--- a/src/io/hdf5_writer.h
+++ b/src/io/hdf5_writer.h
@@ -31,6 +31,7 @@ class HDF5Writer
     void write(const std::string& name, const std::vector<T>& buffer);
     void write_time(const std::string& dataset_name, const std::array<double, 3>& buffer);
     void close();
+    void flush();
 
   private:
     std::string report_name_;


### PR DESCRIPTION
- Call HDF5Writer::flush when the environment variable LIBSONATAREPORT_ENABLE_FLUSH is set and buffers are full to avoid report corruption if the simulation finishes unexpectedly.