### PR TITLE
Improve simulation test

### DIFF
--- a/.github/workflows/simulation_test.yaml
+++ b/.github/workflows/simulation_test.yaml
@@ -169,7 +169,7 @@ jobs:
     - name: Example run
       run: |
         . ./venv/bin/activate
-        if [ ${{ matrix.python-version }} == 3.9.* ]; then
+        if [[ ${{ matrix.python-version }} == 3.9.* ]]; then
           export RDMAV_FORK_SAFE=1
         fi;
         export PYTHONPATH=$(pwd)/nrn/build/lib/python:$PYTHONPATH

--- a/.github/workflows/simulation_test.yaml
+++ b/.github/workflows/simulation_test.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9.20', '3.10.15', '3.11.10', '3.12.6']
     steps:
     - name: Setup Python
       uses: actions/setup-python@v5
@@ -169,7 +169,7 @@ jobs:
     - name: Example run
       run: |
         . ./venv/bin/activate
-        if [ ${{ matrix.python-version }} == 3.9 ]; then
+        if [ ${{ matrix.python-version }} == 3.9.* ]; then
           export RDMAV_FORK_SAFE=1
         fi;
         export PYTHONPATH=$(pwd)/nrn/build/lib/python:$PYTHONPATH

--- a/.github/workflows/simulation_test.yaml
+++ b/.github/workflows/simulation_test.yaml
@@ -26,6 +26,7 @@ on:
 
 env:
   NEURON_COMMIT_ID: 'c48d7d5'
+  RDMAV_FORK_SAFE: '1'
 
 jobs:
   simulation:
@@ -91,11 +92,13 @@ jobs:
         python -m pip install --upgrade pip setuptools
         pip install cython numpy wheel pkgconfig
 
+    - name: Add virtual environment to PATH
+      run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
+
     - name: Install libsonata
       if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
-        . ./venv/bin/activate
-        CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata
+        CC=mpicc CXX=mpic++ pip install git+https://github.com/BlueBrain/libsonata@${{ env.LIBSONATA_BRANCH }}
 
     - name: Install libsonatareport
       run: |
@@ -126,7 +129,6 @@ jobs:
         else
           git clone --branch=${{ env.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git --depth=1
         fi
-        . ./venv/bin/activate
         python -m pip install --upgrade pip -r nrn/nrn_requirements.txt
         cmake -B nrn/build -S nrn -G Ninja \
           -DPYTHON_EXECUTABLE=$(which python) \
@@ -144,15 +146,13 @@ jobs:
     - name: Install h5py
       if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
-        . ./venv/bin/activate
         CC=mpicc CXX=mpic++ pip install --no-binary=h5py h5py
 
     - name: Install neurodamus
       run: |
-        . ./venv/bin/activate
         git clone --branch=${{ env.PY_NEURODAMUS_BRANCH }} https://github.com/BlueBrain/neurodamus.git
         cd neurodamus
-        pip install .
+        pip install .[full]
 
     - name: Build models
       run: |
@@ -168,10 +168,6 @@ jobs:
 
     - name: Example run
       run: |
-        . ./venv/bin/activate
-        if [[ ${{ matrix.python-version }} == 3.9.* ]]; then
-          export RDMAV_FORK_SAFE=1
-        fi;
         export PYTHONPATH=$(pwd)/nrn/build/lib/python:$PYTHONPATH
         cp neurodamus-models/neocortex/hoc/* neurodamus/neurodamus/data/hoc/
         export HOC_LIBRARY_PATH=$(pwd)/neurodamus/neurodamus/data/hoc


### PR DESCRIPTION
GHA setup-python, if not given the full python version, will install the latest patch.
However, since we cache venvs, things can go out of sync we and get errors like
```
/home/runner/work/libsonatareport/libsonatareport/venv/bin/python: bad interpreter: No such file or directory
```