### PR TITLE
[REP-90] Remove warning from existing report

### DIFF
--- a/src/library/reports.cpp
+++ b/src/library/reports.cpp
@@ -16,13 +16,11 @@ int sonata_create_report(const char* report_name,
                          double dt,
                          const char* units,
                          const char* kind) {
+    if (sonata_report.report_exists(report_name)) {
+        return -2;
+    }
     try {
-        if (!sonata_report.report_exists(report_name)) {
-            sonata_report.create_report(report_name, kind, tstart, tend, dt, units);
-        } else {
-            logger->warn("Report '{}' already exists.", report_name);
-            return -2;
-        }
+        sonata_report.create_report(report_name, kind, tstart, tend, dt, units);
     } catch (const std::exception& err) {
         logger->error(err.what());
         return -1;


### PR DESCRIPTION
 - Avoid polluting the log file with prints from each rank
 - Addresses https://github.com/BlueBrain/libsonatareport/issues/48